### PR TITLE
Add mass conservation and Cross model

### DIFF
--- a/flowgo_integrator.py
+++ b/flowgo_integrator.py
@@ -27,7 +27,8 @@ class FlowGoIntegrator:
     and here where the limits are fixed"""
 
     def __init__(self, dx, material_lava, material_air, terrain_condition, heat_budget,
-                 crystallization_rate_model, crust_temperature_model, effective_cover_crust_model):
+                 crystallization_rate_model, crust_temperature_model, effective_cover_crust_model,
+                 mass_conservation):
         """ this function allows to set the initial parameters"""
         self.logger = pyflowgo.flowgo_logger.FlowGoLogger()
         self.dx = dx  # in m
@@ -41,6 +42,7 @@ class FlowGoIntegrator:
         self.material_air = material_air
         self.terrain_condition = terrain_condition
         self.heat_budget = heat_budget
+        self.mass_conservation = mass_conservation
 
     def init_effusion_rate(self, current_state):
 
@@ -90,9 +92,12 @@ class FlowGoIntegrator:
         # be calculated at each step :
         print('distance from vent (m) =', current_state.get_current_position())
 
+        # Switch between volume and mass conservation
         bulk_density = self.material_lava.get_bulk_density(current_state)
-        channel_width = self.flux_rate / (v_mean * channel_depth) / bulk_density
-        #channel_width = self.effusion_rate / (v_mean * channel_depth)
+        if self.mass_conservation:
+            channel_width = self.flux_rate / (v_mean * channel_depth) / bulk_density
+        else: 
+            channel_width = self.effusion_rate / (v_mean * channel_depth)
 
         #TODO: Here I add the slope:ASK MIMI TO MOVE IT FROM HERE
         channel_slope = self.terrain_condition.get_channel_slope(current_state.get_current_position())

--- a/template_cross.json
+++ b/template_cross.json
@@ -1,0 +1,94 @@
+{
+  "lava_name": "template_cross",
+  "slope_file": "resource/example_slope_profile.txt",
+  "step_size": 10.0,
+  "effusion_rate_init" :3,
+
+  "heat_budget_models":{
+   "radiation" : "basic",
+   "snyder":"no",
+   "conduction" : "yes",
+   "convection" : "yes",
+   "rain" : "no",
+   "viscous_heating" : "no"
+  },
+
+  "models":{
+  "crystallization_rate_model":"basic",
+  "melt_viscosity_model":"vft",
+  "relative_viscosity_model":"er",
+  "relative_viscosity_bubbles_model":"no",
+  "yield_strength_model":"basic",
+  "crust_temperature_model":"constant",
+  "effective_cover_crust_model": "basic",
+  "vesicle_fraction_model":"poly"
+  },
+
+  "terrain_conditions":{
+  "width": 4.5,
+  "depth": 1.4,
+  "gravity": 9.81,
+    "slope_smoothing_active": true,
+    "slope_smoothing_number_of_points": 5,
+  "max_channel_length": 30000.0,
+  "mass_conservation": true
+  },
+  "eruption_condition":{
+  "eruption_temperature" : 1387.15,
+  "viscosity_eruption" : 1000.0
+  },
+  "lava_state":{
+  "position" : 0.0,
+  "time" : 1.0,
+  "crystal_fraction": 0.104,
+  "density_dre" : 2970.0,
+  "vesicle_fraction" : 0.83,
+  "vesicle_poly_a": -0.000000003991,
+  "vesicle_poly_b": 0.000001999,
+  "liquidus_temperature": 0.0
+  },
+  "radiation_parameters":{
+    "stefan-boltzmann_sigma" : 5.67e-8,
+    "emissivity_epsilon" : 0.95
+  },
+  "conduction_parameters":{
+    "basal_temperature" : 773.15,
+    "core_base_distance" : 19.0
+  },
+    "rain_parameters":{
+    "rainfall_rate" : 7.93e-8,
+    "density_water" : 958.0,
+    "latent_heat_vaporization" : 2.8e6
+  },
+  "convection_parameters":{
+    "wind_speed" : 5.0,
+    "ch_air" : 0.0036,
+    "air_temperature" : 293.15,
+    "air_density" : 0.4412,
+    "air_specific_heat_capacity":1099.0
+  },
+  "thermal_parameters":{
+    "buffer" : 140.0,
+    "crust_cover_fraction": 1.0,
+    "alpha" : -0.00756,
+    "crust_temperature": 773.15
+  },
+  "melt_viscosity_parameters":{
+    "shaw_slope" :2.36,
+    "a_vft" : -4.52,
+    "b_vft": 5558,
+    "c_vft" : 582.9
+  },
+  "crystals_parameters":{
+    "crystals_grown_during_cooling": 0.896,
+    "solid_temperature": 1237.15,
+    "latent_heat_of_crystallization": 350000.0
+  },
+    "relative_viscosity_parameters":{
+    "max_packing": 0.641,
+    "einstein_coef":3.27,
+	"radius": [[0.005,0.7],[0.0005,0.3]],
+	"surface_tension": 0.37,
+    "strain_rate" : 1.0
+  }
+}


### PR DESCRIPTION
Add flag to switch from volume conservation to mass conservation for bubbly flows. Add quadratic equation for bubble evolution. Add the Cross model for bubble-bearing relative viscosity which uses the calcualted strain rate and a mono- or poly-disperse bubble population to calcualte shear-dependence of bubble rheology.